### PR TITLE
change require parameter to match npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Send push notifications to iOS and Android using [Pushover][site].
 [Register an application with Pushover.net][site-app] to get your application and user tokens. You may optionally set `PUSHOVER_TOKEN` and `PUSHOVER_USER` environment variables to use as default values.
 
 ```js
-var Pushover = require('pushover');
+var Pushover = require('node-pushover-client');
 
 var pushNotification = new Pushover({
   token: 'KzGDORePK8gMaC0QOYAMyEEuzJnyUi',


### PR DESCRIPTION
the sample code failed to run because it was trying to load a package 'pushover' which does exist in npm, but isn't this package.  Once I changed it to node-pushover-client, the code ran and worked great.
